### PR TITLE
Downgrade to .net standard 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Nuget](https://img.shields.io/nuget/v/Parsec.svg)](https://www.nuget.org/packages/Parsec/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-`Parsec` is a simple file parsing library for Shaiya file formats built with C# and .NET Standard 2.1. Its goal is to
+`Parsec` is a simple file parsing library for Shaiya file formats built with C# and .NET Standard 2.0. Its goal is to
 make reading and manipulating the game's file formats easy.
 
 ## Currently supported files/formats

--- a/src/Parsec/Extensions/StringExtensions.cs
+++ b/src/Parsec/Extensions/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Parsec.Extensions
@@ -17,21 +18,7 @@ namespace Parsec.Extensions
         /// <param name="separator">Separator character</param>
         public static string[] Separate(this string text, char? separator = null) =>
             separator == null ? text.Split(_separator) : text.Split((char)separator);
-
-        /// <summary>
-        /// Joins a string array adding a separator character between the elements.
-        /// </summary>
-        /// <param name="stringArray">String array to join</param>
-        /// <param name="separator">Separator character</param>
-        public static string Join(this string[] stringArray, char separator)
-        {
-            var stringBuilder = new StringBuilder();
-
-            stringBuilder.AppendJoin(separator, stringArray);
-
-            return stringBuilder.ToString();
-        }
-
+        
         /// <summary>
         /// The list of invalid characters
         /// </summary>
@@ -43,21 +30,13 @@ namespace Parsec.Extensions
         /// </summary>
         /// <param name="str">String to check</param>
         /// <returns>True if it has invalid characters, false if it doesn't</returns>
-        public static bool HasInvalidCharacters(this string str)
-        {
-            foreach (char c in str)
-            {
-                if (_invalidCharacters.Contains(c))
-                    return true;
-            }
-
-            return false;
-        }
+        public static bool HasInvalidCharacters(this string str) =>
+            str.Any(c => _invalidCharacters.Contains(c.ToString()));
 
         /// <summary>
         /// Converts a string's first character to lowercase
         /// </summary>
         /// <param name="str">String to convert</param>
-        public static string ToCamelCase(this string str) => char.ToLowerInvariant(str[0]) + str[1..];
+        public static string ToCamelCase(this string str) => char.ToLowerInvariant(str[0]) + str.Substring(1, str.Length - 1);
     }
 }

--- a/src/Parsec/Helpers/FileHelper.cs
+++ b/src/Parsec/Helpers/FileHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using Parsec.Extensions;
 
 namespace Parsec.Helpers
 {
@@ -23,15 +25,10 @@ namespace Parsec.Helpers
                 RenameFile(path, $"{path}.bak");
             }
 
-            var separatedPath = path.Split('\\', '/');
-
-            // Ensure directory exists
-            if (separatedPath.Length > 1)
-            {
-                // Create directory path string
-                var directoryPath = string.Join('\\', separatedPath[..^1]);
+            var directoryPath = Path.GetDirectoryName(path);
+            
+            if(!string.IsNullOrEmpty(directoryPath))
                 CreateDirectory(directoryPath);
-            }
 
             // Create file and save data
             using var binaryWriter =
@@ -78,7 +75,7 @@ namespace Parsec.Helpers
         /// <param name="directoryPath">Directory path</param>
         public static void CreateDirectory(string directoryPath)
         {
-            if (DirectoryExists(directoryPath))
+            if (DirectoryExists(directoryPath) || string.IsNullOrEmpty(directoryPath))
                 return;
 
             Directory.CreateDirectory(directoryPath);

--- a/src/Parsec/Parsec.csproj
+++ b/src/Parsec/Parsec.csproj
@@ -10,10 +10,10 @@
         <PackageProjectUrl>https://github.com/matigramirez/Parsec</PackageProjectUrl>
         <RepositoryUrl>https://github.com/matigramirez/Parsec</RepositoryUrl>
         <PackageTags>csharp, shaiya, file, parser, dotnet</PackageTags>
-        <Description>Parsec is a simple file parsing library for Shaiya file formats built with C# and .NET Standard 2.1. Its goal is to make reading and manipulating the game's file formats with ease.</Description>
+        <Description>Parsec is a simple file parsing library for Shaiya file formats built with C# and .NET Standard 2.0. Its goal is to make reading and manipulating the game's file formats with ease.</Description>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <PackageVersion>1.0.0-alpha.4.0.0</PackageVersion>
-        <TargetFrameworks>net5.0;net6.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Parsec/Readers/Reader.cs
+++ b/src/Parsec/Readers/Reader.cs
@@ -40,7 +40,7 @@ namespace Parsec.Readers
             if (!FileHelper.FileExists(path))
                 throw new FileNotFoundException($"File ${path} not found");
 
-            if (path.Length < 6 || path[^5..] != ".json")
+            if (path.Length < 6 || path.Substring(path.Length - 5, 5) != ".json")
                 throw new FileLoadException("The provided file to deserialize must be a valid json file");
 
             // Read json file content
@@ -67,7 +67,8 @@ namespace Parsec.Readers
                 // Check if file extension matches the appropriate FileBase child extension
                 // This is needed since a file could be called MobFox.3DC.json, meaning it already has
                 // its extension after the ".json" part is removed
-                var fileExtension = fileNameWithoutJsonExtension[^objectExtension.Length..];
+                var fileExtension = fileNameWithoutJsonExtension.Substring(
+                    fileNameWithoutJsonExtension.Length - objectExtension.Length, objectExtension.Length);
 
                 if (fileExtension != objectExtension)
                     deserializedObject.Path = $"{fileNameWithoutJsonExtension}.{objectExtension}";

--- a/src/Parsec/Readers/SBinaryReader.cs
+++ b/src/Parsec/Readers/SBinaryReader.cs
@@ -213,8 +213,8 @@ namespace Parsec.Readers
 
             _offset += length;
 
-            if (removeStringTerminator && str.Length > 1 && str[^1] == '\0')
-                str = str[..^1];
+            if (removeStringTerminator && str.Length > 1 && str[str.Length - 1] == '\0')
+                str = str.Substring(0, str.Length - 1);
 
             if (str == "\0")
                 str = "";

--- a/src/Parsec/Shaiya/Data/Data.cs
+++ b/src/Parsec/Shaiya/Data/Data.cs
@@ -39,31 +39,34 @@ namespace Parsec.Shaiya.Data
             if (!FileHelper.FileExists(path))
                 throw new FileNotFoundException($"Data file not found at {path}");
 
-            if (Path.GetExtension(path) == ".sah")
+            switch (Path.GetExtension(path))
             {
-                var safPath = path[..^3] + "saf";
+                case ".sah":
+                {
+                    var safPath = path.Substring(0, path.Length - 3) + "saf";
 
-                if (!FileHelper.FileExists(safPath))
-                    throw new FileNotFoundException(
-                        "A valid saf file must be placed in the same directory as the sah file.");
+                    if (!FileHelper.FileExists(safPath))
+                        throw new FileNotFoundException(
+                            "A valid saf file must be placed in the same directory as the sah file.");
 
-                Sah = Reader.ReadFromFile<Sah>(path);
-                Saf = new Saf(safPath);
-            }
-            else if (Path.GetExtension(path) == ".saf")
-            {
-                var sahPath = path[..^3] + "sah";
+                    Sah = Reader.ReadFromFile<Sah>(path);
+                    Saf = new Saf(safPath);
+                    break;
+                }
+                case ".saf":
+                {
+                    var sahPath = path.Substring(0, path.Length - 3) + "sah";
 
-                if (!FileHelper.FileExists(sahPath))
-                    throw new FileNotFoundException(
-                        "A valid sah file must be placed in the same directory as the saf file.");
+                    if (!FileHelper.FileExists(sahPath))
+                        throw new FileNotFoundException(
+                            "A valid sah file must be placed in the same directory as the saf file.");
 
-                Sah = Reader.ReadFromFile<Sah>(sahPath);
-                Saf = new Saf(path);
-            }
-            else
-            {
-                throw new ArgumentException("The provided path must belong to either a .sah or a .saf file");
+                    Sah = Reader.ReadFromFile<Sah>(sahPath);
+                    Saf = new Saf(path);
+                    break;
+                }
+                default:
+                    throw new ArgumentException("The provided path must belong to either a .sah or a .saf file");
             }
         }
 

--- a/src/Parsec/Shaiya/Data/SFile.cs
+++ b/src/Parsec/Shaiya/Data/SFile.cs
@@ -73,7 +73,7 @@ namespace Parsec.Shaiya.Data
             // Write folder's relative path based on parent folder
             RelativePath = ParentFolder == null || ParentFolder.Name == ""
                 ? Name
-                : string.Join('/', folder.RelativePath, Name);
+                : string.Join("/", folder.RelativePath, Name);
 
             // Add file to the sah's file dictionary
             if (!fileIndex.ContainsKey(RelativePath))

--- a/src/Parsec/Shaiya/Data/SFolder.cs
+++ b/src/Parsec/Shaiya/Data/SFolder.cs
@@ -62,7 +62,7 @@ namespace Parsec.Shaiya.Data
             // Write folder's relative path based on parent folder
             RelativePath = parentFolder == null || parentFolder.Name == ""
                 ? Name
-                : string.Join('/', parentFolder.RelativePath, Name);
+                : string.Join("/", parentFolder.RelativePath, Name);
 
             folderIndex.Add(RelativePath, this);
 

--- a/src/Parsec/Shaiya/SData/SData.cs
+++ b/src/Parsec/Shaiya/SData/SData.cs
@@ -83,7 +83,7 @@ namespace Parsec.Shaiya.SData
             // Encrypt in chunks of 16 bytes
             for (var i = 0; i < alignmentSize / 16; ++i)
             {
-                var data16 = data[(i * 16)..((i + 1) * 16)];
+                var data16 = data.SubArray(i * 16, 16);
                 SEED.EncryptChunk(data16, out var encryptedData16);
                 buffer.AddRange(encryptedData16);
             }
@@ -109,7 +109,7 @@ namespace Parsec.Shaiya.SData
             var header = new SDataHeader(encryptedBuffer);
 
             // Get data without header
-            var encryptedData = encryptedBuffer[64..];
+            var encryptedData = encryptedBuffer.SubArray(64, encryptedBuffer.Length - 64);
 
             // Create array of decrypted data
             var data = new List<byte>();
@@ -118,7 +118,7 @@ namespace Parsec.Shaiya.SData
             for (var i = 0; i < encryptedData.Length / 16; ++i)
             {
                 // Get 16 bytes
-                var data16 = encryptedData[(i * 16)..((i + 1) * 16)];
+                var data16 = encryptedData.SubArray(i * 16, 16);
 
                 // Decrypt seed
                 SEED.DecryptChunk(data16, out var decryptedData16);

--- a/src/Parsec/Shaiya/SData/SDataHeader.cs
+++ b/src/Parsec/Shaiya/SData/SDataHeader.cs
@@ -31,8 +31,8 @@ namespace Parsec.Shaiya.SData
         public SDataHeader(byte[] data)
         {
             Signature = Encoding.ASCII.GetString(data.SubArray(0, 40));
-            Checksum = BitConverter.ToUInt32(data.SubArray(40, 4));
-            RealSize = BitConverter.ToUInt32(data.SubArray(44, 4));
+            Checksum = BitConverter.ToUInt32(data, 40);
+            RealSize = BitConverter.ToUInt32(data, 44);
             Padding = data.SubArray(48, 16);
         }
     }

--- a/tests/Parsec.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/Parsec.Tests/Extensions/StringExtensionsTests.cs
@@ -23,14 +23,6 @@ namespace Parsec.Tests.Extensions
             }
         }
 
-        [Theory]
-        [InlineData(new[] { "C:", "Users", "Parsec", "filename.ext" }, "C:\\Users\\Parsec\\filename.ext", '\\')]
-        [InlineData(new[] { "C:", "Users", "Parsec", "filename.ext" }, "C:/Users/Parsec/filename.ext", '/')]
-        public void JoinTest(string[] stringArray, string jointString, char separator)
-        {
-            Assert.Equal(jointString, stringArray.Join(separator));
-        }
-
         [Fact]
         public void InvalidCharactersTest()
         {


### PR DESCRIPTION
Although I don't entirely like giving up the features of modern C#, I understand the need of making the library available on .NET Framework too, that's why it was necessary to downgrade to .NET Standard 2.0.

These changes are mostly because of the extensive use of Index/Range on arrays and strings, there are no major changes other than that.