### PR TITLE
NpcFaction and rename FarmItems

### DIFF
--- a/src/Parsec/Shaiya/NpcQuest/BaseNpc.cs
+++ b/src/Parsec/Shaiya/NpcQuest/BaseNpc.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using Parsec.Common;
 using Parsec.Extensions;
 using Parsec.Readers;
-using Parsec.Shaiya.Common;
 using Parsec.Shaiya.Core;
 
 namespace Parsec.Shaiya.NpcQuest
@@ -16,7 +15,7 @@ namespace Parsec.Shaiya.NpcQuest
         public int Model { get; set; }
         public int MoveDistance { get; set; }
         public int MoveSpeed { get; set; }
-        public FactionInt Faction { get; set; }
+        public NpcFaction Faction { get; set; }
         public string Name { get; set; }
         public string WelcomeMessage { get; set; }
 
@@ -52,7 +51,7 @@ namespace Parsec.Shaiya.NpcQuest
             Model = binaryReader.Read<int>();
             MoveDistance = binaryReader.Read<int>();
             MoveSpeed = binaryReader.Read<int>();
-            Faction = (FactionInt)binaryReader.Read<int>();
+            Faction = (NpcFaction)binaryReader.Read<int>();
 
             if (_format < Format.EP8) // In ep 8, messages are moved to separate translation files.
             {

--- a/src/Parsec/Shaiya/NpcQuest/NpcFaction.cs
+++ b/src/Parsec/Shaiya/NpcQuest/NpcFaction.cs
@@ -1,6 +1,6 @@
 ﻿namespace Parsec.Shaiya.NpcQuest
 {
-    public enum NpcFaction: byte
+    public enum NpcFaction
     {
         Any,
         Light,

--- a/src/Parsec/Shaiya/NpcQuest/NpcFaction.cs
+++ b/src/Parsec/Shaiya/NpcQuest/NpcFaction.cs
@@ -1,0 +1,9 @@
+﻿namespace Parsec.Shaiya.NpcQuest
+{
+    public enum NpcFaction: byte
+    {
+        Any,
+        Light,
+        Fury
+    }
+}

--- a/src/Parsec/Shaiya/NpcQuest/Quest.cs
+++ b/src/Parsec/Shaiya/NpcQuest/Quest.cs
@@ -75,7 +75,7 @@ namespace Parsec.Shaiya.NpcQuest
         /// <summary>
         /// 3 for EP4 and EP5?
         /// </summary>
-        public List<QuestItem> RewardItems { get; } = new();
+        public List<QuestItem> FarmItems { get; } = new();
 
         /// <summary>
         /// byPCKillCount = pvp kills?
@@ -186,7 +186,7 @@ namespace Parsec.Shaiya.NpcQuest
             for (int i = 0; i < 3; i++)
             {
                 var rewardItem = new QuestItem(binaryReader);
-                RewardItems.Add(rewardItem);
+                FarmItems.Add(rewardItem);
             }
 
             PvpKillCount = binaryReader.Read<byte>();
@@ -276,7 +276,7 @@ namespace Parsec.Shaiya.NpcQuest
             buffer.Add(EndNpcType);
             buffer.AddRange(EndNpcId.GetBytes());
 
-            buffer.AddRange(RewardItems.GetBytes());
+            buffer.AddRange(FarmItems.GetBytes());
 
             buffer.Add(PvpKillCount);
             buffer.AddRange(RequiredMobId1.GetBytes());


### PR DESCRIPTION
`FactionInt` for npc is incorrect. For light it has value 1, for fury is 2.
Can be easily checked via "Raigo Guard":
![image](https://user-images.githubusercontent.com/8158404/168759722-1291442a-7ae8-4dfb-b211-9bba9618e94d.png)
