### PR TITLE
FileBase: JsonSerialize exclude only HTML symbols

### DIFF
--- a/src/Parsec/Shaiya/Core/FileBase.cs
+++ b/src/Parsec/Shaiya/Core/FileBase.cs
@@ -52,7 +52,7 @@ public abstract class FileBase : IJsonWritable<FileBase>
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             DefaultValueHandling = DefaultValueHandling.Include,
-            StringEscapeHandling = StringEscapeHandling.EscapeNonAscii,
+            StringEscapeHandling = StringEscapeHandling.EscapeHtml,
             Formatting = Formatting.Indented
         };
 


### PR DESCRIPTION
Hi, this required to display cyrillic symbols without escaping inside JSON files.
Before:
` {
      "id": 1,
      "skillLevel": 1,
      "name": "\u0422\u0440\u0435\u043d\u0438\u0440\u043e\u0432\u043a\u0430 \u043c\u044b\u0448\u0446, \u0443\u0440. 1",
      "text": "\u041f\u0430\u0441\u0441\u0438\u0432\u043d\u044b\u0439 \u043d\u0430\u0432\u044b\u043a, \u0443\u0441\u0438\u043b\u0438\u0432\u0430\u044e\u0449\u0438\u0439 \u0444\u0438\u0437\u0438\u0447\u0435\u0441\u043a\u0443\u044e \u0430\u0442\u0430\u043a\u0443 \u043d\u0430 10."
    }`

After:
`{
      "id": 1,
      "skillLevel": 1,
      "name": "Тренировка мышц, ур. 1",
      "text": "Пассивный навык, усиливающий физическую атаку на 10."
    }`