### PR TITLE
Cloak physics serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Unity and Godot.
 - `3DO`
 - `3DE`
 - `MLT`
+- `PC` (Cloak physics)
 - `ITM`
 - `SMOD`
 - `EFT`

--- a/src/Parsec/Shaiya/Cloak/Physics/Pc.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/Pc.cs
@@ -9,6 +9,9 @@ namespace Parsec.Shaiya.Cloak.Physics;
 /// </summary>
 public sealed class Pc : FileBase
 {
+    public const int MaximumMeshReferenceCount = 1024;
+    public const int MaximumClothLinkCount = 4096;
+
     /// <summary>
     /// Flexible .3DC meshes used by the cloth simulation.
     /// </summary>
@@ -29,23 +32,27 @@ public sealed class Pc : FileBase
 
     protected override void Read(SBinaryReader binaryReader)
     {
-        var flexibleMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, "flexible mesh");
+        var flexibleMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, MaximumMeshReferenceCount, "flexible mesh");
         FlexibleMeshes = binaryReader.ReadList<PcMeshReference>(flexibleMeshCount);
 
-        var linkCount = ReadCount(binaryReader, PcClothLink.SerializedSize, "cloth link");
+        var linkCount = ReadCount(binaryReader, PcClothLink.SerializedSize, MaximumClothLinkCount, "cloth link");
         Links = binaryReader.ReadList<PcClothLink>(linkCount);
 
-        var rigidMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, "rigid mesh");
+        var rigidMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, MaximumMeshReferenceCount, "rigid mesh");
         RigidMeshes = binaryReader.ReadList<PcMeshReference>(rigidMeshCount);
 
         if (binaryReader.Position != binaryReader.StreamLength)
         {
             throw new InvalidDataException($"The .PC file has {binaryReader.StreamLength - binaryReader.Position} trailing bytes.");
         }
+
+        ValidateStructure();
     }
 
     protected override void Write(SBinaryWriter binaryWriter)
     {
+        ValidateStructure();
+
         binaryWriter.Write((uint)FlexibleMeshes.Count);
         binaryWriter.Write(FlexibleMeshes, lengthPrefixed: false);
 
@@ -56,16 +63,48 @@ public sealed class Pc : FileBase
         binaryWriter.Write(RigidMeshes, lengthPrefixed: false);
     }
 
-    private static int ReadCount(SBinaryReader binaryReader, int recordSize, string sectionName)
+    private static int ReadCount(SBinaryReader binaryReader, int recordSize, int maximum, string sectionName)
     {
         var count = binaryReader.ReadUInt32();
         var remainingByteCount = binaryReader.StreamLength - binaryReader.Position;
 
-        if (count > int.MaxValue || (long)count * recordSize > remainingByteCount)
+        if (count > maximum || (long)count * recordSize > remainingByteCount)
         {
             throw new InvalidDataException($"The .PC file has an invalid {sectionName} count of {count}.");
         }
 
         return (int)count;
+    }
+
+    private void ValidateStructure()
+    {
+        if (FlexibleMeshes.Count > MaximumMeshReferenceCount)
+        {
+            throw new InvalidDataException($"A .PC file cannot contain more than {MaximumMeshReferenceCount} flexible meshes.");
+        }
+
+        if (Links.Count > MaximumClothLinkCount)
+        {
+            throw new InvalidDataException($"A .PC file cannot contain more than {MaximumClothLinkCount} cloth links.");
+        }
+
+        if (RigidMeshes.Count > MaximumMeshReferenceCount)
+        {
+            throw new InvalidDataException($"A .PC file cannot contain more than {MaximumMeshReferenceCount} rigid meshes.");
+        }
+
+        for (var i = 0; i < Links.Count; i++)
+        {
+            var link = Links[i];
+            if (link.ClothMeshIndex < 0 || link.ClothMeshIndex >= FlexibleMeshes.Count)
+            {
+                throw new InvalidDataException($"Cloth link {i} has an invalid flexible mesh index of {link.ClothMeshIndex}.");
+            }
+
+            if (link.RigidMeshIndex < 0 || link.RigidMeshIndex >= RigidMeshes.Count)
+            {
+                throw new InvalidDataException($"Cloth link {i} has an invalid rigid mesh index of {link.RigidMeshIndex}.");
+            }
+        }
     }
 }

--- a/src/Parsec/Shaiya/Cloak/Physics/Pc.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/Pc.cs
@@ -1,0 +1,71 @@
+using Newtonsoft.Json;
+using Parsec.Serialization;
+using Parsec.Shaiya.Core;
+
+namespace Parsec.Shaiya.Cloak.Physics;
+
+/// <summary>
+/// Represents a .PC cloak-physics configuration.
+/// </summary>
+public sealed class Pc : FileBase
+{
+    /// <summary>
+    /// Flexible .3DC meshes used by the cloth simulation.
+    /// </summary>
+    public List<PcMeshReference> FlexibleMeshes { get; set; } = new();
+
+    /// <summary>
+    /// Links between flexible cloth meshes, textures, rigid meshes, and skeleton anchors.
+    /// </summary>
+    public List<PcClothLink> Links { get; set; } = new();
+
+    /// <summary>
+    /// Rigid .3DC meshes used to bind the cloth to an animated skeleton.
+    /// </summary>
+    public List<PcMeshReference> RigidMeshes { get; set; } = new();
+
+    [JsonIgnore]
+    public override string Extension => "PC";
+
+    protected override void Read(SBinaryReader binaryReader)
+    {
+        var flexibleMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, "flexible mesh");
+        FlexibleMeshes = binaryReader.ReadList<PcMeshReference>(flexibleMeshCount);
+
+        var linkCount = ReadCount(binaryReader, PcClothLink.SerializedSize, "cloth link");
+        Links = binaryReader.ReadList<PcClothLink>(linkCount);
+
+        var rigidMeshCount = ReadCount(binaryReader, PcMeshReference.SerializedSize, "rigid mesh");
+        RigidMeshes = binaryReader.ReadList<PcMeshReference>(rigidMeshCount);
+
+        if (binaryReader.Position != binaryReader.StreamLength)
+        {
+            throw new InvalidDataException($"The .PC file has {binaryReader.StreamLength - binaryReader.Position} trailing bytes.");
+        }
+    }
+
+    protected override void Write(SBinaryWriter binaryWriter)
+    {
+        binaryWriter.Write((uint)FlexibleMeshes.Count);
+        binaryWriter.Write(FlexibleMeshes, lengthPrefixed: false);
+
+        binaryWriter.Write((uint)Links.Count);
+        binaryWriter.Write(Links, lengthPrefixed: false);
+
+        binaryWriter.Write((uint)RigidMeshes.Count);
+        binaryWriter.Write(RigidMeshes, lengthPrefixed: false);
+    }
+
+    private static int ReadCount(SBinaryReader binaryReader, int recordSize, string sectionName)
+    {
+        var count = binaryReader.ReadUInt32();
+        var remainingByteCount = binaryReader.StreamLength - binaryReader.Position;
+
+        if (count > int.MaxValue || (long)count * recordSize > remainingByteCount)
+        {
+            throw new InvalidDataException($"The .PC file has an invalid {sectionName} count of {count}.");
+        }
+
+        return (int)count;
+    }
+}

--- a/src/Parsec/Shaiya/Cloak/Physics/PcAnchor.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcAnchor.cs
@@ -19,17 +19,30 @@ public sealed class PcAnchor : ISerializable
 
     public void Read(SBinaryReader binaryReader)
     {
-        IsActive = binaryReader.ReadUInt32() != 0;
+        IsActive = binaryReader.ReadUInt32() == 1;
         ClothVertex = binaryReader.ReadInt32();
         SkeletonBone = binaryReader.ReadInt32();
         BoneLocalPosition = binaryReader.Read<Vector3>();
+        ValidatePosition();
     }
 
     public void Write(SBinaryWriter binaryWriter)
     {
+        ValidatePosition();
+
         binaryWriter.Write(IsActive ? 1u : 0u);
         binaryWriter.Write(ClothVertex);
         binaryWriter.Write(SkeletonBone);
         binaryWriter.Write(BoneLocalPosition);
+    }
+
+    private void ValidatePosition()
+    {
+        if (float.IsNaN(BoneLocalPosition.X) || float.IsInfinity(BoneLocalPosition.X) ||
+            float.IsNaN(BoneLocalPosition.Y) || float.IsInfinity(BoneLocalPosition.Y) ||
+            float.IsNaN(BoneLocalPosition.Z) || float.IsInfinity(BoneLocalPosition.Z))
+        {
+            throw new InvalidDataException("A .PC anchor position must contain finite values.");
+        }
     }
 }

--- a/src/Parsec/Shaiya/Cloak/Physics/PcAnchor.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcAnchor.cs
@@ -1,0 +1,35 @@
+using Parsec.Serialization;
+using Parsec.Shaiya.Common;
+using Parsec.Shaiya.Core;
+
+namespace Parsec.Shaiya.Cloak.Physics;
+
+/// <summary>
+/// Binds a flexible-mesh vertex to a bone in the rigid mesh's skeleton.
+/// </summary>
+public sealed class PcAnchor : ISerializable
+{
+    public bool IsActive { get; set; }
+
+    public int ClothVertex { get; set; }
+
+    public int SkeletonBone { get; set; }
+
+    public Vector3 BoneLocalPosition { get; set; }
+
+    public void Read(SBinaryReader binaryReader)
+    {
+        IsActive = binaryReader.ReadUInt32() != 0;
+        ClothVertex = binaryReader.ReadInt32();
+        SkeletonBone = binaryReader.ReadInt32();
+        BoneLocalPosition = binaryReader.Read<Vector3>();
+    }
+
+    public void Write(SBinaryWriter binaryWriter)
+    {
+        binaryWriter.Write(IsActive ? 1u : 0u);
+        binaryWriter.Write(ClothVertex);
+        binaryWriter.Write(SkeletonBone);
+        binaryWriter.Write(BoneLocalPosition);
+    }
+}

--- a/src/Parsec/Shaiya/Cloak/Physics/PcClothLink.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcClothLink.cs
@@ -1,0 +1,80 @@
+using Parsec.Serialization;
+using Parsec.Shaiya.Core;
+
+namespace Parsec.Shaiya.Cloak.Physics;
+
+/// <summary>
+/// Describes one simulated cloth grid and its relationship to render and skeleton resources.
+/// </summary>
+public sealed class PcClothLink : ISerializable
+{
+    public const int AnchorCount = 20;
+    public const int SerializedSize = 0x20c;
+
+    public int ClothMeshIndex { get; set; }
+
+    public int TextureIndex { get; set; }
+
+    public int SolverMode { get; set; }
+
+    public int RigidMeshIndex { get; set; }
+
+    public int ColumnSegments { get; set; }
+
+    public int RowSegments { get; set; }
+
+    public int SampleColumn { get; set; }
+
+    public int SampleRow { get; set; }
+
+    public int SampleRadiusColumn { get; set; }
+
+    public int SampleRadiusRow { get; set; }
+
+    /// <summary>
+    /// Reserved 32-bit field. PS0198 files commonly contain the debug-fill value 0xCDCDCDCD.
+    /// </summary>
+    public uint Padding { get; set; }
+
+    /// <summary>
+    /// The format always stores exactly 20 anchor slots, including inactive slots.
+    /// </summary>
+    public List<PcAnchor> Anchors { get; set; } = new();
+
+    public void Read(SBinaryReader binaryReader)
+    {
+        ClothMeshIndex = binaryReader.ReadInt32();
+        TextureIndex = binaryReader.ReadInt32();
+        SolverMode = binaryReader.ReadInt32();
+        RigidMeshIndex = binaryReader.ReadInt32();
+        ColumnSegments = binaryReader.ReadInt32();
+        RowSegments = binaryReader.ReadInt32();
+        SampleColumn = binaryReader.ReadInt32();
+        SampleRow = binaryReader.ReadInt32();
+        SampleRadiusColumn = binaryReader.ReadInt32();
+        SampleRadiusRow = binaryReader.ReadInt32();
+        Padding = binaryReader.ReadUInt32();
+        Anchors = binaryReader.ReadList<PcAnchor>(AnchorCount);
+    }
+
+    public void Write(SBinaryWriter binaryWriter)
+    {
+        if (Anchors.Count != AnchorCount)
+        {
+            throw new InvalidDataException($"A .PC cloth link must contain exactly {AnchorCount} anchor slots.");
+        }
+
+        binaryWriter.Write(ClothMeshIndex);
+        binaryWriter.Write(TextureIndex);
+        binaryWriter.Write(SolverMode);
+        binaryWriter.Write(RigidMeshIndex);
+        binaryWriter.Write(ColumnSegments);
+        binaryWriter.Write(RowSegments);
+        binaryWriter.Write(SampleColumn);
+        binaryWriter.Write(SampleRow);
+        binaryWriter.Write(SampleRadiusColumn);
+        binaryWriter.Write(SampleRadiusRow);
+        binaryWriter.Write(Padding);
+        binaryWriter.Write(Anchors, lengthPrefixed: false);
+    }
+}

--- a/src/Parsec/Shaiya/Cloak/Physics/PcClothLink.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcClothLink.cs
@@ -55,14 +55,12 @@ public sealed class PcClothLink : ISerializable
         SampleRadiusRow = binaryReader.ReadInt32();
         Padding = binaryReader.ReadUInt32();
         Anchors = binaryReader.ReadList<PcAnchor>(AnchorCount);
+        Validate();
     }
 
     public void Write(SBinaryWriter binaryWriter)
     {
-        if (Anchors.Count != AnchorCount)
-        {
-            throw new InvalidDataException($"A .PC cloth link must contain exactly {AnchorCount} anchor slots.");
-        }
+        Validate();
 
         binaryWriter.Write(ClothMeshIndex);
         binaryWriter.Write(TextureIndex);
@@ -76,5 +74,18 @@ public sealed class PcClothLink : ISerializable
         binaryWriter.Write(SampleRadiusRow);
         binaryWriter.Write(Padding);
         binaryWriter.Write(Anchors, lengthPrefixed: false);
+    }
+
+    private void Validate()
+    {
+        if (Anchors.Count != AnchorCount)
+        {
+            throw new InvalidDataException($"A .PC cloth link must contain exactly {AnchorCount} anchor slots.");
+        }
+
+        if (ColumnSegments < 1 || RowSegments < 1)
+        {
+            throw new InvalidDataException("A .PC cloth link must have at least one row and column segment.");
+        }
     }
 }

--- a/src/Parsec/Shaiya/Cloak/Physics/PcMeshReference.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcMeshReference.cs
@@ -39,6 +39,7 @@ public sealed class PcMeshReference : ISerializable
         }
 
         FileName = binaryReader.SerializationOptions.Encoding.GetString(buffer, 0, terminatorIndex);
+        ValidateFileName();
 
         FileNamePadding = new byte[FileNameBufferSize - terminatorIndex];
         Buffer.BlockCopy(buffer, terminatorIndex, FileNamePadding, 0, FileNamePadding.Length);
@@ -46,6 +47,8 @@ public sealed class PcMeshReference : ISerializable
 
     public void Write(SBinaryWriter binaryWriter)
     {
+        ValidateFileName();
+
         if (FileName.IndexOf('\0') >= 0)
         {
             throw new InvalidDataException("A .PC mesh filename cannot contain a null character.");
@@ -73,6 +76,14 @@ public sealed class PcMeshReference : ISerializable
         else
         {
             binaryWriter.Write(new byte[remainingByteCount]);
+        }
+    }
+
+    private void ValidateFileName()
+    {
+        if (string.IsNullOrEmpty(FileName))
+        {
+            throw new InvalidDataException("A .PC mesh reference must have a filename.");
         }
     }
 }

--- a/src/Parsec/Shaiya/Cloak/Physics/PcMeshReference.cs
+++ b/src/Parsec/Shaiya/Cloak/Physics/PcMeshReference.cs
@@ -1,0 +1,78 @@
+using Parsec.Serialization;
+using Parsec.Shaiya.Core;
+
+namespace Parsec.Shaiya.Cloak.Physics;
+
+/// <summary>
+/// References a mesh by its table identifier and fixed-width filename.
+/// </summary>
+public sealed class PcMeshReference : ISerializable
+{
+    public const int FileNameBufferSize = 128;
+    public const int SerializedSize = sizeof(int) + FileNameBufferSize;
+
+    public int Id { get; set; }
+
+    public string FileName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bytes from the first null terminator to the end of the 128-byte filename buffer.
+    /// Keeping this tail allows buffers initialized with non-zero padding to round-trip exactly.
+    /// When the filename is changed, an incompatible tail is replaced with null padding.
+    /// </summary>
+    public byte[] FileNamePadding { get; set; } = Array.Empty<byte>();
+
+    public void Read(SBinaryReader binaryReader)
+    {
+        Id = binaryReader.ReadInt32();
+
+        var buffer = binaryReader.ReadBytes(FileNameBufferSize);
+        if (buffer.Length != FileNameBufferSize)
+        {
+            throw new EndOfStreamException("The .PC mesh filename buffer is truncated.");
+        }
+
+        var terminatorIndex = Array.IndexOf(buffer, (byte)0);
+        if (terminatorIndex < 0)
+        {
+            terminatorIndex = FileNameBufferSize;
+        }
+
+        FileName = binaryReader.SerializationOptions.Encoding.GetString(buffer, 0, terminatorIndex);
+
+        FileNamePadding = new byte[FileNameBufferSize - terminatorIndex];
+        Buffer.BlockCopy(buffer, terminatorIndex, FileNamePadding, 0, FileNamePadding.Length);
+    }
+
+    public void Write(SBinaryWriter binaryWriter)
+    {
+        if (FileName.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException("A .PC mesh filename cannot contain a null character.");
+        }
+
+        var fileNameBytes = binaryWriter.SerializationOptions.Encoding.GetBytes(FileName);
+        if (fileNameBytes.Length > FileNameBufferSize)
+        {
+            throw new InvalidDataException($"A .PC mesh filename cannot exceed {FileNameBufferSize} bytes.");
+        }
+
+        binaryWriter.Write(Id);
+        binaryWriter.Write(fileNameBytes);
+
+        var remainingByteCount = FileNameBufferSize - fileNameBytes.Length;
+        if (remainingByteCount == 0)
+        {
+            return;
+        }
+
+        if (FileNamePadding.Length == remainingByteCount && FileNamePadding[0] == 0)
+        {
+            binaryWriter.Write(FileNamePadding);
+        }
+        else
+        {
+            binaryWriter.Write(new byte[remainingByteCount]);
+        }
+    }
+}

--- a/tests/Parsec.Tests/Shaiya/Cloak/PcTests.cs
+++ b/tests/Parsec.Tests/Shaiya/Cloak/PcTests.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Parsec.Shaiya.Cloak.Physics;
+using Parsec.Shaiya.Common;
+
+namespace Parsec.Tests.Shaiya.Cloak;
+
+public class PcTests
+{
+    [Fact]
+    public void PcReadWriteTest()
+    {
+        var pc = new Pc
+        {
+            FlexibleMeshes = new List<PcMeshReference>
+            {
+                CreateMeshReference(3, "humf_cloak_flexible.3DC")
+            },
+            Links = new List<PcClothLink>
+            {
+                new()
+                {
+                    ClothMeshIndex = 0,
+                    TextureIndex = 7,
+                    SolverMode = 1,
+                    RigidMeshIndex = 0,
+                    ColumnSegments = 4,
+                    RowSegments = 6,
+                    SampleColumn = 2,
+                    SampleRow = 1,
+                    SampleRadiusColumn = 2,
+                    SampleRadiusRow = 3,
+                    Padding = 0xcdcdcdcd,
+                    Anchors = Enumerable.Range(0, PcClothLink.AnchorCount)
+                        .Select(index => new PcAnchor
+                        {
+                            IsActive = index < 5,
+                            ClothVertex = index,
+                            SkeletonBone = index + 10,
+                            BoneLocalPosition = new Vector3(index + 0.25f, index + 0.5f, index + 0.75f)
+                        })
+                        .ToList()
+                }
+            },
+            RigidMeshes = new List<PcMeshReference>
+            {
+                CreateMeshReference(9, "humf_cloak_rigid.3DC")
+            }
+        };
+
+        var bytes = pc.GetBytes().ToArray();
+        var parsed = ParsecReader.FromBuffer<Pc>("sample.PC", bytes);
+
+        Assert.Equal(800, bytes.Length);
+        Assert.Equal("humf_cloak_flexible.3DC", parsed.FlexibleMeshes[0].FileName);
+        Assert.Equal(0xcdcdcdcd, parsed.Links[0].Padding);
+        Assert.Equal(20, parsed.Links[0].Anchors.Count);
+        Assert.True(parsed.Links[0].Anchors[0].IsActive);
+        Assert.False(parsed.Links[0].Anchors[5].IsActive);
+        Assert.Equal(bytes, parsed.GetBytes());
+
+        var parsedFromJson = ParsecReader.FromJson<Pc>("sample.PC", parsed.JsonSerialize());
+        Assert.Equal(bytes, parsedFromJson.GetBytes());
+    }
+
+    [Fact]
+    public void PcRejectsTruncatedSections()
+    {
+        var truncatedBuffer = new byte[4 + PcMeshReference.SerializedSize - 1];
+        truncatedBuffer[0] = 1;
+
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("truncated.PC", truncatedBuffer));
+    }
+
+    [Fact]
+    public void PcRequiresTwentyAnchorSlotsWhenWriting()
+    {
+        var pc = new Pc
+        {
+            Links = new List<PcClothLink>
+            {
+                new()
+            }
+        };
+
+        Assert.Throws<InvalidDataException>(() => pc.GetBytes());
+    }
+
+    private static PcMeshReference CreateMeshReference(int id, string fileName)
+    {
+        var fileNamePadding = Enumerable.Repeat((byte)0xcd, PcMeshReference.FileNameBufferSize - fileName.Length).ToArray();
+        fileNamePadding[0] = 0;
+
+        return new PcMeshReference
+        {
+            Id = id,
+            FileName = fileName,
+            FileNamePadding = fileNamePadding
+        };
+    }
+}

--- a/tests/Parsec.Tests/Shaiya/Cloak/PcTests.cs
+++ b/tests/Parsec.Tests/Shaiya/Cloak/PcTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,43 +12,7 @@ public class PcTests
     [Fact]
     public void PcReadWriteTest()
     {
-        var pc = new Pc
-        {
-            FlexibleMeshes = new List<PcMeshReference>
-            {
-                CreateMeshReference(3, "humf_cloak_flexible.3DC")
-            },
-            Links = new List<PcClothLink>
-            {
-                new()
-                {
-                    ClothMeshIndex = 0,
-                    TextureIndex = 7,
-                    SolverMode = 1,
-                    RigidMeshIndex = 0,
-                    ColumnSegments = 4,
-                    RowSegments = 6,
-                    SampleColumn = 2,
-                    SampleRow = 1,
-                    SampleRadiusColumn = 2,
-                    SampleRadiusRow = 3,
-                    Padding = 0xcdcdcdcd,
-                    Anchors = Enumerable.Range(0, PcClothLink.AnchorCount)
-                        .Select(index => new PcAnchor
-                        {
-                            IsActive = index < 5,
-                            ClothVertex = index,
-                            SkeletonBone = index + 10,
-                            BoneLocalPosition = new Vector3(index + 0.25f, index + 0.5f, index + 0.75f)
-                        })
-                        .ToList()
-                }
-            },
-            RigidMeshes = new List<PcMeshReference>
-            {
-                CreateMeshReference(9, "humf_cloak_rigid.3DC")
-            }
-        };
+        var pc = CreateValidPc();
 
         var bytes = pc.GetBytes().ToArray();
         var parsed = ParsecReader.FromBuffer<Pc>("sample.PC", bytes);
@@ -85,6 +50,81 @@ public class PcTests
         };
 
         Assert.Throws<InvalidDataException>(() => pc.GetBytes());
+    }
+
+    [Fact]
+    public void PcMatchesEftrenderValidationRules()
+    {
+        const int flexibleFileNameOffset = sizeof(uint) + sizeof(int);
+        const int linkOffset = sizeof(uint) + PcMeshReference.SerializedSize + sizeof(uint);
+        const int columnSegmentsOffset = linkOffset + sizeof(int) * 4;
+        const int firstAnchorOffset = linkOffset + sizeof(int) * 11;
+        const int firstAnchorPositionOffset = firstAnchorOffset + sizeof(int) * 3;
+
+        var emptyFileName = CreateValidPc().GetBytes().ToArray();
+        emptyFileName[flexibleFileNameOffset] = 0;
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("empty-name.PC", emptyFileName));
+
+        var invalidGrid = CreateValidPc().GetBytes().ToArray();
+        BitConverter.GetBytes(0).CopyTo(invalidGrid, columnSegmentsOffset);
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("invalid-grid.PC", invalidGrid));
+
+        var invalidReference = CreateValidPc().GetBytes().ToArray();
+        BitConverter.GetBytes(1).CopyTo(invalidReference, linkOffset);
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("invalid-reference.PC", invalidReference));
+
+        var invalidPosition = CreateValidPc().GetBytes().ToArray();
+        BitConverter.GetBytes(float.NaN).CopyTo(invalidPosition, firstAnchorPositionOffset);
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("invalid-position.PC", invalidPosition));
+
+        var excessiveCount = BitConverter.GetBytes((uint)Pc.MaximumMeshReferenceCount + 1);
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<Pc>("excessive-count.PC", excessiveCount));
+
+        var nonCanonicalActiveFlag = CreateValidPc().GetBytes().ToArray();
+        BitConverter.GetBytes(2u).CopyTo(nonCanonicalActiveFlag, firstAnchorOffset);
+        var parsed = ParsecReader.FromBuffer<Pc>("active-flag.PC", nonCanonicalActiveFlag);
+        Assert.False(parsed.Links[0].Anchors[0].IsActive);
+    }
+
+    private static Pc CreateValidPc()
+    {
+        return new Pc
+        {
+            FlexibleMeshes = new List<PcMeshReference>
+            {
+                CreateMeshReference(3, "humf_cloak_flexible.3DC")
+            },
+            Links = new List<PcClothLink>
+            {
+                new()
+                {
+                    ClothMeshIndex = 0,
+                    TextureIndex = 7,
+                    SolverMode = 1,
+                    RigidMeshIndex = 0,
+                    ColumnSegments = 4,
+                    RowSegments = 6,
+                    SampleColumn = 2,
+                    SampleRow = 1,
+                    SampleRadiusColumn = 2,
+                    SampleRadiusRow = 3,
+                    Padding = 0xcdcdcdcd,
+                    Anchors = Enumerable.Range(0, PcClothLink.AnchorCount)
+                        .Select(index => new PcAnchor
+                        {
+                            IsActive = index < 5,
+                            ClothVertex = index,
+                            SkeletonBone = index + 10,
+                            BoneLocalPosition = new Vector3(index + 0.25f, index + 0.5f, index + 0.75f)
+                        })
+                        .ToList()
+                }
+            },
+            RigidMeshes = new List<PcMeshReference>
+            {
+                CreateMeshReference(9, "humf_cloak_rigid.3DC")
+            }
+        };
     }
 
     private static PcMeshReference CreateMeshReference(int id, string fileName)


### PR DESCRIPTION
Adds parsing, binary serialization and JSON conversion support for Shaiya's `.PC` files. Example JSON usage:
```csharp
using Parsec.Shaiya.Cloak.Physics;

var pc = ParsecReader.FromFile<Pc>("cloak.pc");
pc.WriteJson("cloak.pc.json");
```

This format was reverse engineered from the ps0198 Ep6 game client, and has validation rules to ensure the formats match specific boundaries. With this change, Parsec successfully validates all 128 `.PC` files present in the Ep6 client. Using this format, a physics simulator is available here: https://cupsocino.github.io/effect-renderer/