### PR TITLE
Refactor parsing of ENV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Unity and Godot.
 - `NpcSkill.SData`
 - `svmap`
 - `WLD`
+- `ENV` (Environment timelines)
 - `dg`
 - `ANI`
 - `3DC`

--- a/src/Parsec/Shaiya/Env/Env.cs
+++ b/src/Parsec/Shaiya/Env/Env.cs
@@ -3,25 +3,75 @@ using Parsec.Shaiya.Core;
 
 namespace Parsec.Shaiya.Env;
 
+/// <summary>
+/// Represents a V2 environment timeline.
+/// </summary>
 public sealed class Env : FileBase
 {
-    private const int HeaderLength = 2;
+    public const int MaximumRecordCount = 64;
 
-    public string Header { get; set; } = "V2";
+    private const string ExpectedHeader = "V2";
+
+    public string Header { get; set; } = ExpectedHeader;
 
     public List<EnvRecord> Records { get; set; } = new();
 
-    public override string Extension { get; } = "env";
+    public override string Extension => "env";
 
     protected override void Read(SBinaryReader binaryReader)
     {
-        Header = binaryReader.ReadString(HeaderLength);
-        Records = binaryReader.ReadList<EnvRecord>();
+        if (binaryReader.StreamLength < 6)
+        {
+            throw new InvalidDataException("The .ENV file does not contain a valid V2 header.");
+        }
+
+        try
+        {
+            var header = binaryReader.ReadBytes(ExpectedHeader.Length);
+            if (header.Length != ExpectedHeader.Length || header[0] != (byte)'V' || header[1] != (byte)'2')
+            {
+                throw new InvalidDataException("The .ENV file does not contain a valid V2 header.");
+            }
+
+            Header = ExpectedHeader;
+
+            var recordCount = binaryReader.ReadUInt32();
+            if (recordCount == 0 || recordCount > MaximumRecordCount)
+            {
+                throw new InvalidDataException($"The .ENV file has an invalid record count of {recordCount}.");
+            }
+
+            Records = new List<EnvRecord>((int)recordCount);
+            for (var i = 0; i < recordCount; i++)
+            {
+                Records.Add(binaryReader.Read<EnvRecord>());
+            }
+
+            if (binaryReader.Position != binaryReader.StreamLength)
+            {
+                throw new InvalidDataException($"The .ENV file has {binaryReader.StreamLength - binaryReader.Position} trailing bytes.");
+            }
+        }
+        catch (EndOfStreamException exception)
+        {
+            throw new InvalidDataException("The .ENV file is truncated.", exception);
+        }
     }
 
     protected override void Write(SBinaryWriter binaryWriter)
     {
-        binaryWriter.Write(Header.Take(HeaderLength).ToString(), isLengthPrefixed: false, includeStringTerminator: false);
-        binaryWriter.Write(Records);
+        if (Header != ExpectedHeader)
+        {
+            throw new InvalidDataException("An .ENV file must use the V2 header.");
+        }
+
+        if (Records == null || Records.Count == 0 || Records.Count > MaximumRecordCount)
+        {
+            throw new InvalidDataException($"An .ENV file must contain between 1 and {MaximumRecordCount} records.");
+        }
+
+        binaryWriter.Write(new[] { (byte)'V', (byte)'2' });
+        binaryWriter.Write((uint)Records.Count);
+        binaryWriter.Write(Records, lengthPrefixed: false);
     }
 }

--- a/src/Parsec/Shaiya/Env/EnvColor.cs
+++ b/src/Parsec/Shaiya/Env/EnvColor.cs
@@ -3,25 +3,51 @@ using Parsec.Shaiya.Core;
 
 namespace Parsec.Shaiya.Env;
 
+/// <summary>
+/// An .ENV RGB color normalized to the range 0 through 1.
+/// </summary>
 public struct EnvColor : ISerializable
 {
-    public int Red { get; set; }
+    private const float MaximumEncodedChannel = 255f;
 
-    public int Green { get; set; }
+    public float Red { get; set; }
 
-    public int Blue { get; set; }
+    public float Green { get; set; }
+
+    public float Blue { get; set; }
 
     public void Read(SBinaryReader binaryReader)
     {
-        Red = binaryReader.ReadInt32();
-        Green = binaryReader.ReadInt32();
-        Blue = binaryReader.ReadInt32();
+        Red = ReadChannel(binaryReader);
+        Green = ReadChannel(binaryReader);
+        Blue = ReadChannel(binaryReader);
     }
 
     public void Write(SBinaryWriter binaryWriter)
     {
-        binaryWriter.Write(Red);
-        binaryWriter.Write(Green);
-        binaryWriter.Write(Blue);
+        binaryWriter.Write(EncodeChannel(Red));
+        binaryWriter.Write(EncodeChannel(Green));
+        binaryWriter.Write(EncodeChannel(Blue));
+    }
+
+    private static float ReadChannel(SBinaryReader binaryReader)
+    {
+        var value = binaryReader.ReadInt32();
+        if (value < 0 || value > MaximumEncodedChannel)
+        {
+            throw new InvalidDataException($"The .ENV file contains an invalid color channel of {value}.");
+        }
+
+        return value / MaximumEncodedChannel;
+    }
+
+    private static int EncodeChannel(float value)
+    {
+        if (float.IsNaN(value) || float.IsInfinity(value) || value < 0 || value > 1)
+        {
+            throw new InvalidDataException($"An .ENV color channel must be between 0 and 1, but was {value}.");
+        }
+
+        return (int)Math.Round(value * MaximumEncodedChannel, MidpointRounding.AwayFromZero);
     }
 }

--- a/src/Parsec/Shaiya/Env/EnvRecord.cs
+++ b/src/Parsec/Shaiya/Env/EnvRecord.cs
@@ -3,81 +3,209 @@ using Parsec.Shaiya.Core;
 
 namespace Parsec.Shaiya.Env;
 
+/// <summary>
+/// Describes one normal or weather interval in an environment timeline.
+/// </summary>
 public sealed class EnvRecord : ISerializable
 {
-    public int Unknown1 { get; set; }
+    public const int ColorCount = 3;
+    public const int SkyNameCount = 4;
+    public const int LightingParameterCount = 6;
+    public const int MaximumSkyNameByteLength = 4096;
+    public const int MinutesPerDay = 24 * 60;
 
-    public int Unknown2 { get; set; }
+    public ushort StartMinute { get; set; }
 
-    public EnvColor Color1 { get; set; }
+    public ushort EndMinute { get; set; }
 
-    public EnvColor Color2 { get; set; }
+    public EnvColor[] Colors { get; set; } = new EnvColor[ColorCount];
 
-    public EnvColor Color3 { get; set; }
+    public string[] SkyNames { get; set; } =
+    {
+        "empty.tga",
+        "empty.tga",
+        "empty.tga",
+        "empty.tga"
+    };
 
-    public string SkyName1 { get; set; } = "empty.tga";
+    public float[] Lighting { get; set; } = new float[LightingParameterCount];
 
-    public string SkyName2 { get; set; } = "empty.tga";
+    public bool Weather { get; set; }
 
-    public string SkyName3 { get; set; } = "empty.tga";
-
-    public string SkyName4 { get; set; } = "empty.tga";
-
-    public float Unknown12 { get; set; }
-
-    public float Unknown13 { get; set; }
-
-    public float Unknown14 { get; set; }
-
-    public float Unknown15 { get; set; }
-
-    public float Unknown16 { get; set; }
-
-    public float Unknown17 { get; set; }
-
-    public byte UnknownByte18 { get; set; }
-
-    public int Unknown19 { get; set; }
+    public uint TransitionMilliseconds { get; set; }
 
     public void Read(SBinaryReader binaryReader)
     {
-        Unknown1 = binaryReader.ReadInt32();
-        Unknown2 = binaryReader.ReadInt32();
-        Color1 = binaryReader.Read<EnvColor>();
-        Color2 = binaryReader.Read<EnvColor>();
-        Color3 = binaryReader.Read<EnvColor>();
-        SkyName1 = binaryReader.ReadString();
-        SkyName2 = binaryReader.ReadString();
-        SkyName3 = binaryReader.ReadString();
-        SkyName4 = binaryReader.ReadString();
-        Unknown12 = binaryReader.ReadSingle();
-        Unknown13 = binaryReader.ReadSingle();
-        Unknown14 = binaryReader.ReadSingle();
-        Unknown15 = binaryReader.ReadSingle();
-        Unknown16 = binaryReader.ReadSingle();
-        Unknown17 = binaryReader.ReadSingle();
-        UnknownByte18 = binaryReader.ReadByte();
-        Unknown19 = binaryReader.ReadInt32();
+        StartMinute = DecodeTime(binaryReader.ReadInt32());
+        EndMinute = DecodeTime(binaryReader.ReadInt32());
+
+        Colors = new EnvColor[ColorCount];
+        for (var i = 0; i < Colors.Length; i++)
+        {
+            Colors[i] = binaryReader.Read<EnvColor>();
+        }
+
+        SkyNames = new string[SkyNameCount];
+        for (var i = 0; i < SkyNames.Length; i++)
+        {
+            SkyNames[i] = ReadSkyName(binaryReader);
+        }
+
+        Lighting = new float[LightingParameterCount];
+        for (var i = 0; i < Lighting.Length; i++)
+        {
+            var value = binaryReader.ReadSingle();
+            ValidateLighting(value);
+            Lighting[i] = value;
+        }
+
+        Weather = binaryReader.ReadByte() != 0;
+
+        var transitionMilliseconds = binaryReader.ReadInt32();
+        if (transitionMilliseconds < 0)
+        {
+            throw new InvalidDataException("An .ENV transition duration cannot be negative.");
+        }
+
+        TransitionMilliseconds = (uint)transitionMilliseconds;
     }
 
     public void Write(SBinaryWriter binaryWriter)
     {
-        binaryWriter.Write(Unknown1);
-        binaryWriter.Write(Unknown2);
-        binaryWriter.Write(Color1);
-        binaryWriter.Write(Color2);
-        binaryWriter.Write(Color3);
-        binaryWriter.Write(SkyName1, includeStringTerminator: false);
-        binaryWriter.Write(SkyName2, includeStringTerminator: false);
-        binaryWriter.Write(SkyName3, includeStringTerminator: false);
-        binaryWriter.Write(SkyName4, includeStringTerminator: false);
-        binaryWriter.Write(Unknown12);
-        binaryWriter.Write(Unknown13);
-        binaryWriter.Write(Unknown14);
-        binaryWriter.Write(Unknown15);
-        binaryWriter.Write(Unknown16);
-        binaryWriter.Write(Unknown17);
-        binaryWriter.Write(UnknownByte18);
-        binaryWriter.Write(Unknown19);
+        ValidateStructure(binaryWriter);
+
+        binaryWriter.Write(EncodeTime(StartMinute));
+        binaryWriter.Write(EncodeTime(EndMinute));
+
+        foreach (var color in Colors)
+        {
+            binaryWriter.Write(color);
+        }
+
+        foreach (var skyName in SkyNames)
+        {
+            WriteSkyName(binaryWriter, skyName);
+        }
+
+        foreach (var value in Lighting)
+        {
+            binaryWriter.Write(value);
+        }
+
+        binaryWriter.Write(Weather ? (byte)1 : (byte)0);
+        binaryWriter.Write((int)TransitionMilliseconds);
+    }
+
+    private static ushort DecodeTime(int value)
+    {
+        if (value < 0)
+        {
+            throw new InvalidDataException($"The .ENV file contains an invalid time of {value}.");
+        }
+
+        var hour = value / 100;
+        var minute = value % 100;
+        if (hour > 23 || minute > 59)
+        {
+            throw new InvalidDataException($"The .ENV file contains an invalid time of {value}.");
+        }
+
+        return (ushort)(hour * 60 + minute);
+    }
+
+    private static int EncodeTime(ushort minuteOfDay)
+    {
+        ValidateMinute(minuteOfDay);
+        return minuteOfDay / 60 * 100 + minuteOfDay % 60;
+    }
+
+    private static string ReadSkyName(SBinaryReader binaryReader)
+    {
+        var byteLength = binaryReader.ReadUInt32();
+        if (byteLength > MaximumSkyNameByteLength)
+        {
+            throw new InvalidDataException($"An .ENV sky name cannot exceed {MaximumSkyNameByteLength} bytes.");
+        }
+
+        if (byteLength > binaryReader.StreamLength - binaryReader.Position)
+        {
+            throw new InvalidDataException("The .ENV file contains a truncated sky name.");
+        }
+
+        var bytes = binaryReader.ReadBytes((int)byteLength);
+        return binaryReader.SerializationOptions.Encoding.GetString(bytes);
+    }
+
+    private static void WriteSkyName(SBinaryWriter binaryWriter, string skyName)
+    {
+        if (skyName == null)
+        {
+            throw new InvalidDataException("An .ENV sky name cannot be null.");
+        }
+
+        var bytes = binaryWriter.SerializationOptions.Encoding.GetBytes(skyName);
+        if (bytes.Length > MaximumSkyNameByteLength)
+        {
+            throw new InvalidDataException($"An .ENV sky name cannot exceed {MaximumSkyNameByteLength} bytes.");
+        }
+
+        binaryWriter.Write((uint)bytes.Length);
+        binaryWriter.Write(bytes);
+    }
+
+    private void ValidateStructure(SBinaryWriter binaryWriter)
+    {
+        ValidateMinute(StartMinute);
+        ValidateMinute(EndMinute);
+
+        if (Colors == null || Colors.Length != ColorCount)
+        {
+            throw new InvalidDataException($"An .ENV record must contain exactly {ColorCount} colors.");
+        }
+
+        if (SkyNames == null || SkyNames.Length != SkyNameCount)
+        {
+            throw new InvalidDataException($"An .ENV record must contain exactly {SkyNameCount} sky names.");
+        }
+
+        foreach (var skyName in SkyNames)
+        {
+            var byteLength = skyName == null ? -1 : binaryWriter.SerializationOptions.Encoding.GetByteCount(skyName);
+            if (byteLength < 0 || byteLength > MaximumSkyNameByteLength)
+            {
+                throw new InvalidDataException($"An .ENV sky name must contain at most {MaximumSkyNameByteLength} bytes.");
+            }
+        }
+
+        if (Lighting == null || Lighting.Length != LightingParameterCount)
+        {
+            throw new InvalidDataException($"An .ENV record must contain exactly {LightingParameterCount} lighting parameters.");
+        }
+
+        foreach (var value in Lighting)
+        {
+            ValidateLighting(value);
+        }
+
+        if (TransitionMilliseconds > int.MaxValue)
+        {
+            throw new InvalidDataException($"An .ENV transition duration cannot exceed {int.MaxValue} milliseconds.");
+        }
+    }
+
+    private static void ValidateMinute(ushort minuteOfDay)
+    {
+        if (minuteOfDay >= MinutesPerDay)
+        {
+            throw new InvalidDataException($"An .ENV minute-of-day value must be less than {MinutesPerDay}.");
+        }
+    }
+
+    private static void ValidateLighting(float value)
+    {
+        if (float.IsNaN(value) || float.IsInfinity(value) || value < 0 || value > 100)
+        {
+            throw new InvalidDataException($"The .ENV file contains an invalid lighting value of {value}.");
+        }
     }
 }

--- a/tests/Parsec.Tests/Shaiya/Env/EnvTests.cs
+++ b/tests/Parsec.Tests/Shaiya/Env/EnvTests.cs
@@ -1,0 +1,149 @@
+using System.IO;
+using System.Linq;
+using Parsec.Shaiya.Env;
+
+using EnvFile = Parsec.Shaiya.Env.Env;
+
+namespace Parsec.Tests.Shaiya.Environment;
+
+public class EnvTests
+{
+    [Fact]
+    public void EnvParsesTeststuffV2LayoutAndRoundTrips()
+    {
+        var bytes = CreateEnvironment();
+
+        var env = ParsecReader.FromBuffer<EnvFile>("sample.env", bytes);
+
+        Assert.Equal("V2", env.Header);
+        Assert.Single(env.Records);
+
+        var record = env.Records[0];
+        Assert.Equal((ushort)600, record.StartMinute);
+        Assert.Equal((ushort)1439, record.EndMinute);
+        Assert.Equal(EnvRecord.ColorCount, record.Colors.Length);
+        Assert.Equal(128f / 255f, record.Colors[0].Red);
+        Assert.Equal(64f / 255f, record.Colors[0].Green);
+        Assert.Equal(32f / 255f, record.Colors[0].Blue);
+        Assert.Equal(new[] { "sky.bmp", "cloud.tga", "empty.tga", "empty.tga" }, record.SkyNames);
+        Assert.Equal(new[] { 0.5f, 0.8f, 2.15f, 1.1f, 1.3f, 1.4f }, record.Lighting);
+        Assert.False(record.Weather);
+        Assert.Equal((uint)60_000, record.TransitionMilliseconds);
+        Assert.Equal(bytes, env.GetBytes());
+
+        var fromJson = ParsecReader.FromJson<EnvFile>("sample.env", env.JsonSerialize());
+        Assert.Equal(bytes, fromJson.GetBytes());
+    }
+
+    [Fact]
+    public void EnvTreatsEveryNonZeroWeatherFlagAsTrue()
+    {
+        var env = ParsecReader.FromBuffer<EnvFile>("weather.env", CreateEnvironment(weather: 2));
+
+        Assert.True(env.Records[0].Weather);
+    }
+
+    [Fact]
+    public void EnvRejectsInvalidHeaderAndRecordCounts()
+    {
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("short.env", new byte[5]));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("header.env", CreateHeaderAndCount("V1", 1)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("empty.env", CreateHeaderAndCount("V2", 0)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("large.env", CreateHeaderAndCount("V2", EnvFile.MaximumRecordCount + 1)));
+    }
+
+    [Fact]
+    public void EnvRejectsInvalidRecordValues()
+    {
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("time.env", CreateEnvironment(startTime: 2400)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("color.env", CreateEnvironment(red: 256)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("lighting.env", CreateEnvironment(firstLighting: float.NaN)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("transition.env", CreateEnvironment(transitionMilliseconds: -1)));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("name.env", CreateEnvironment(firstSkyName: new string('x', EnvRecord.MaximumSkyNameByteLength + 1))));
+    }
+
+    [Fact]
+    public void EnvRejectsTruncationAndTrailingData()
+    {
+        var valid = CreateEnvironment();
+        var truncated = valid.Take(valid.Length - 1).ToArray();
+        var trailing = valid.Concat(new byte[] { 0xcd }).ToArray();
+
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("truncated.env", truncated));
+        Assert.Throws<InvalidDataException>(() => ParsecReader.FromBuffer<EnvFile>("trailing.env", trailing));
+    }
+
+    [Fact]
+    public void EnvWriterOnlyProducesValidV2Files()
+    {
+        Assert.Throws<InvalidDataException>(() => new EnvFile().GetBytes());
+
+        var env = ParsecReader.FromBuffer<EnvFile>("sample.env", CreateEnvironment());
+        env.Header = "V1";
+        Assert.Throws<InvalidDataException>(() => env.GetBytes());
+
+        env.Header = "V2";
+        env.Records[0].Colors[0] = new EnvColor { Red = 2, Green = 0, Blue = 0 };
+        Assert.Throws<InvalidDataException>(() => env.GetBytes());
+    }
+
+    private static byte[] CreateHeaderAndCount(string header, int count)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write(System.Text.Encoding.ASCII.GetBytes(header));
+        writer.Write(count);
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateEnvironment(
+        int startTime = 1000,
+        int red = 128,
+        float firstLighting = 0.5f,
+        byte weather = 0,
+        int transitionMilliseconds = 60_000,
+        string firstSkyName = "sky.bmp")
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+
+        writer.Write(new[] { (byte)'V', (byte)'2' });
+        writer.Write(1);
+        writer.Write(startTime);
+        writer.Write(2359);
+
+        WriteColor(writer, red, 64, 32);
+        WriteColor(writer, 10, 20, 30);
+        WriteColor(writer, 200, 210, 220);
+
+        WriteString(writer, firstSkyName);
+        WriteString(writer, "cloud.tga");
+        WriteString(writer, "empty.tga");
+        WriteString(writer, "empty.tga");
+
+        writer.Write(firstLighting);
+        writer.Write(0.8f);
+        writer.Write(2.15f);
+        writer.Write(1.1f);
+        writer.Write(1.3f);
+        writer.Write(1.4f);
+        writer.Write(weather);
+        writer.Write(transitionMilliseconds);
+
+        return stream.ToArray();
+    }
+
+    private static void WriteColor(BinaryWriter writer, int red, int green, int blue)
+    {
+        writer.Write(red);
+        writer.Write(green);
+        writer.Write(blue);
+    }
+
+    private static void WriteString(BinaryWriter writer, string value)
+    {
+        var bytes = System.Text.Encoding.ASCII.GetBytes(value);
+        writer.Write(bytes.Length);
+        writer.Write(bytes);
+    }
+}


### PR DESCRIPTION
Refactored the .ENV parser to accurately mirror what I've implemented in a test renderer made from refactoring ps0032-gamigo. 
-  Decode HH:MM timestamps into minute-of-day values.
- RGB channels are normalized 0-1
- Exposes sky layer, lighting parameters and transition duration.
- Validates expected fields

This parse is able to parse 115 ENV files from ps0032, rejecting only `140.env`.